### PR TITLE
deps: update nix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ authors = ["paul@colomiets.name"]
 
 [dependencies]
 libc = "0.2"
-nix = "0.26"
+nix = { version = "0.27", features = ["mount", "user"] }
 quick-error = "2.0"
 
 [dev-dependencies]


### PR DESCRIPTION
The nix revision contains support for loongarch64.